### PR TITLE
feat(SEO): 自动网站地图生成 和 robots.txt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/SitemapCreatorStable.yml
+++ b/.github/workflows/SitemapCreatorStable.yml
@@ -23,7 +23,7 @@ jobs:
         uses: DuckDuckStudio/Sitemap_Creator@1.0.1
         with:
           location: "sitemap.xml"
-          basic_link: "https://jiaziyi007.github.io/"
+          basic_link: "https://jiaziyi007.github.io"
           file_type: "html"
           ignore_file: "gb2312.html"
           website_path: "./"

--- a/.github/workflows/SitemapCreatorStable.yml
+++ b/.github/workflows/SitemapCreatorStable.yml
@@ -1,0 +1,32 @@
+name: 生成 Sitemap
+
+# GitHub Actiion DuckDuckStudio/Sitemap_Creator 版本 1.0.1 示例工作流
+# https://github.com/marketplace/actions/sitemap-creator-stable
+# Under the [GNU Affero General Public License v3.0](https://github.com/DuckDuckStudio/Sitemap_Creator/blob/main/LICENSE)
+
+on:
+  push:
+    branches:
+      - main
+      # 当 main 分支上有新推送且以下文件被更改时
+    paths:
+      - '**/*.html'
+      - '**/*.md'
+  workflow_dispatch: # 手动运行
+
+jobs:
+  generate_sitemap:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 更新网站地图
+        uses: DuckDuckStudio/Sitemap_Creator@1.0.1
+        with:
+          location: "sitemap.xml"
+          basic_link: "https://jiaziyi007.github.io/"
+          file_type: "html"
+          ignore_file: "gb2312.html"
+          website_path: "./"
+          labels: "Sitemap Creator"
+          # auto_merge: "压缩合并" - 如果你为你的仓库启用了自动合并，可以选择加上这个参数
+          debug: true # 启用调试输出

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,1 @@
+Sitemap: https://jiaziyi007.github.io/sitemap.xml


### PR DESCRIPTION
> 我是来~~推销~~我的GitHub Action的。  
> [Sitemap Creator - 用 GitHub Action 🚀 在你的仓库中创建和更新网站地图。](https://github.com/marketplace/actions/sitemap-creator-stable)  

什么是 SEO：https://developer.mozilla.org/zh-CN/docs/Glossary/SEO - 简单来说就是提升你的网站在搜索结果中的排名
什么是网站地图(Sitemap)：https://developer.mozilla.org/zh-CN/docs/Glossary/SEO - 告诉搜索引擎网站上的网址，省得爬虫去爬还没爬到
什么是 robots.txt：https://developer.mozilla.org/zh-CN/docs/Glossary/Robots.txt - 在此修改中用于告诉爬虫网站地图的位置

为什么要做 SEO：SEO可以优化网站在搜索引擎中的结果的排名，使网站中的内容更容易在其他用户搜索时看到。添加网站地图属于 SEO 的一个方法。

为什么每次修改网站地图 Sitemap Creator 都要新建一个拉取请求：Sitemap Creator目前还处于早期阶段，为了防止意外修改，我让Sitemap Creator在修改时都先建个拉取请求来供审查，如果没啥问题合并就行。如果你希望加快审查，可以[启用自动合并](https://docs.github.com/zh/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request)。

为什么要添加 dependabot.yml：这是 [Dependabot 版本更新](https://docs.github.com/zh/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) 的配置文件，当 Sitemap Creator 发布新版本后，Dependabot 会自动提交一个拉取请求来让您审查，您可以合并拉取请求来更新仓库中使用的 Sitemap Creator 的版本

为什么要使用 Sitemap Creator 而不是其他方式更新网站地图：因为 Sitemap Creator 是我维护的。

工作流成功运行需要什么：
1. 给GitHub Action写入权限并允许GitHub Action创建拉取请求 - [怎么做](https://github.com/DuckDuckStudio/Sitemap_Creator?tab=readme-ov-file#1-%E5%A6%82%E4%BD%95%E5%85%81%E8%AE%B8-github-action-%E5%88%9B%E5%BB%BA%E6%8B%89%E5%8F%96%E8%AF%B7%E6%B1%82)
2. 为仓库添加名为 `Sitemap Creator`的标签

效果示例：
- https://github.com/DuckDuckStudio/JIAZIYI007.github.io/pull/6

有其他任何问题可以向此拉取请求添加评论询问；如有任何需要修改的（例如修改添加的标签名），请[提出修改请求](https://docs.github.com/zh/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/reviewing-proposed-changes-in-a-pull-request)。🙏