### PR TITLE
[WIP] chore: 从触发条件中移除 Markdown 文件

### DIFF
--- a/.github/workflows/SitemapCreatorStable.yml
+++ b/.github/workflows/SitemapCreatorStable.yml
@@ -11,7 +11,6 @@ on:
       # 当 main 分支上有新推送且以下文件被更改时
     paths:
       - '**/*.html'
-      - '**/*.md'
   workflow_dispatch: # 手动运行
 
 jobs:


### PR DESCRIPTION
建个拉取请求确认下网站文件中确实没有/以后也没有(不过以后可以再加回去) `.md` 文件，如果有则需要修改忽略文件参数

转草稿原因：
1. 新 Workflow WIP
2. Sitemap Creator 需要升级